### PR TITLE
Minify grid JSON files to save space

### DIFF
--- a/Assets/Scripts/SaveAndLoad.cs
+++ b/Assets/Scripts/SaveAndLoad.cs
@@ -81,7 +81,7 @@ public class SaveAndLoad : MonoBehaviour
         }
 
         // Save layoutData to current layout's file. If in tutorial mode, instead save to the temporary tutorial file
-        string jsonString = JsonUtility.ToJson(layoutData, true);
+        string jsonString = JsonUtility.ToJson(layoutData, false);
 
         if (tutorial.tutorialMode && !File.Exists(tutorialFile))
             Debug.LogError("tutorial file not found");


### PR DESCRIPTION
This makes the JSON files used to save the grid about 2.5 times smaller by removing the whitespace.